### PR TITLE
Add Realtek driver r8152 v2.18.1

### DIFF
--- a/SOURCES/fix-conditional-check-for-kernel-version.patch
+++ b/SOURCES/fix-conditional-check-for-kernel-version.patch
@@ -1,0 +1,26 @@
+Fix build using 4.19.0 kernel headers
+
+
+When using build-env docker container provided by xcp-ng, the original
+source code fails to build with this error:
+    /home/builder/rpmbuild/BUILD/r8152-2.18.1/compatibility.h:562:21: error: redefinition of 'skb_mark_not_on_list'
+    static inline void skb_mark_not_on_list(struct sk_buff *skb)
+
+It is because the kernel headers provided in build env are for 4.19.0 kernel,
+ even though system uses later patch version.
+This commit lowers the precision of the conditional check for kernel version to 4.19.0.
+
+Signed-off-by: Vasyl Solovei <iam@miltador.pro>
+diff --git a/compatibility.h b/compatibility.h
+index b33c894..d756a18 100644
+--- a/compatibility.h
++++ b/compatibility.h
+@@ -557,7 +557,7 @@
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0) */
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) */
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0) */
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,10) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0) && \
+     !(LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,217) && LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+        static inline void skb_mark_not_on_list(struct sk_buff *skb)
+        {

--- a/SOURCES/r8152-alt-2.18.1.tar.gz
+++ b/SOURCES/r8152-alt-2.18.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b89379da1941a1ec2661a69fe123c8785bb35be486a4fb49c35ed5f38f48762d
+size 110194

--- a/SPECS/r8152-module-alt.spec
+++ b/SPECS/r8152-module-alt.spec
@@ -1,0 +1,58 @@
+%define vendor_name Realtek
+%define vendor_label realtek
+%define driver_name r8152
+
+%if %undefined module_dir
+%define module_dir extra
+%endif
+
+Summary: %{vendor_name} %{driver_name} device drivers
+Name: %{driver_name}-module-alt
+Version: 2.18.1
+Release: 1%{?dist}
+License: GPL
+
+#Source taken from https://github.com/wget/realtek-r8152-linux/archive/refs/tags/v2.18.1.20240701.tar.gz
+Source0: %{driver_name}-alt-%{version}.tar.gz
+Patch0: fix-conditional-check-for-kernel-version.patch
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Provides: vendor-driver
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+%description
+%{vendor_name} %{driver_name} device drivers for the Linux Kernel
+version %{kernel_version}.
+
+%prep
+%autosetup -p1 -n %{driver_name}-%{version}
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) KSRC=/lib/modules/%{kernel_version}/build modules
+
+%install
+%{__make} %{?_smp_mflags} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+
+%changelog
+* Sat Oct 05 2024 Vasyl Solovei <iam@miltador.pro> - 2.18.1-1
+- Adding Realtek driver r8152 v2.18.1


### PR DESCRIPTION
It all started here: https://xcp-ng.org/forum/topic/9736/rtl8156bg-support-any-chance-to-get-updated-r8152-driver-from-newer-kernel/

I went ahead and packaged a newer Realtek driver version from sources found here: https://github.com/wget/realtek-r8152-linux

It's my first try to package something for RPM, but I used xcp-ng build-env and after adding a patch on top of the driver, it all compiled successfully and I tested it on my hardware and it works.
Keep in mind it requires an [udev rules](https://github.com/wget/realtek-r8152-linux/blob/master/50-usb-realtek-net.rules) file (pretty much as other USB drivers do) and, in my case with RTL8156BG, I need to manually set 2.5GB link like so:
`ethtool -s eth0 autoneg on advertise 0x80000000002f`
Or if you want it permanently you can use this command on your PIF interface:
`xe pif-param-set uuid=<pif-uuid> other-config:ethtool-advertise="0x80000000002f"`

Also usb auto suspend and power management need to be disabled, there are a few simple [udev rules](https://askubuntu.com/a/1222000) to do that.

A warning about sources tarball: Github has a stupid limitation, it doesn't allow to upload Git LFS object to forks so this PR contains a broken reference to source and requires someone from repo contributors to upload [actual sources tarball](https://github.com/goodness-from-me-forks/r8152-module-alt2/blob/master/SOURCES/r8152-alt-2.18.1.tar.gz) from my other repo.
