### PR TITLE
Vendor driver r8152 version 2.19.2

### DIFF
--- a/SOURCES/0001-compat.patch
+++ b/SOURCES/0001-compat.patch
@@ -1,0 +1,11 @@
+--- compatibility.h.orig	2023-09-29 00:25:40.774230131 +0000
++++ compatibility.h	2023-09-29 00:35:17.648831271 +0000
+@@ -551,7 +551,7 @@
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0) */
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) */
+ #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0) */
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,10) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0) && \
+     !(LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,217) && LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+ 	static inline void skb_mark_not_on_list(struct sk_buff *skb)
+ 	{

--- a/SOURCES/0002-disable-tx-checksum.patch
+++ b/SOURCES/0002-disable-tx-checksum.patch
@@ -1,0 +1,12 @@
+--- r8152.c.orig	2024-11-13 20:34:39.366113609 +0000
++++ r8152.c	2024-11-13 20:41:05.621152316 +0000
+@@ -26918,6 +26918,9 @@
+ 				NETIF_F_IPV6_CSUM | NETIF_F_TSO6;
+ #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39) */
+ 
++	/* Turn off TX CSUM and TSO by default for XCP */
++	netdev->features &= ~(NETIF_F_IP_CSUM|NETIF_F_TSO|NETIF_F_IPV6_CSUM|NETIF_F_TSO6);
++
+ 	if (tp->version == RTL_VER_01) {
+ 		netdev->features &= ~NETIF_F_RXCSUM;
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)

--- a/SOURCES/0003-remove-useless-warning.patch
+++ b/SOURCES/0003-remove-useless-warning.patch
@@ -1,0 +1,11 @@
+--- r8152.c.orig	2024-11-13 04:54:34.560324560 +0000
++++ r8152.c	2024-11-13 04:56:01.661895630 +0000
+@@ -1198,7 +1198,7 @@
+ 
+ 	/* both size and indix must be 4 bytes align */
+ 	if ((size & 3) || !size || (index & 3) || !data) {
+-		WARN_ON_ONCE(1);
++/*		WARN_ON_ONCE(1); */ /* Dire kernel warning is unwarranted */
+ 		return -EPERM;
+ 	}
+ 

--- a/SOURCES/0004-install-rules-non-root.patch
+++ b/SOURCES/0004-install-rules-non-root.patch
@@ -1,0 +1,11 @@
+--- r8152-module-alt-2.19.2/Makefile.orig	2025-02-21 12:02:48.544001316 +0100
++++ r8152-module-alt-2.19.2/Makefile	2025-02-21 12:03:19.568449504 +0100
+@@ -54,7 +54,7 @@
+ 
+ .PHONY: install_rules
+ install_rules:
+-	install --group=root --owner=root --mode=0644 $(RULEFILE) $(RULEDIR)
++	install --mode=0644 $(RULEFILE) $(RULEDIR)
+ 
+ endif
+ 

--- a/SOURCES/r8152-module-alt-2.19.2.tar.gz
+++ b/SOURCES/r8152-module-alt-2.19.2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de4a696fda7135e0f6f6762d079d21cfcbb17e323b5eb270dfc569a40926d9a4
+size 111057

--- a/SPECS/r8152-module-alt.spec
+++ b/SPECS/r8152-module-alt.spec
@@ -1,0 +1,65 @@
+%define module_dir updates
+
+Summary: Driver for Realtek r8152
+Name: r8152-module-alt
+Version: 2.19.2
+Release: 1%{?dist}
+License: GPL
+# Sources extracted from the Linux kernel %{version}
+Source: %{name}-%{version}.tar.gz
+
+Patch0: 0001-compat.patch
+Patch1: 0002-disable-tx-checksum.patch
+Patch2: 0003-remove-useless-warning.patch
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+
+%description
+Realtek r8152 device drivers for the Linux Kernel version %{kernel_version}.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) modules
+
+%install
+%{__make} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+mkdir -p %{buildroot}/etc/udev/rules.d
+%{__make} RULEDIR=%{buildroot}/etc/udev/rules.d install_rules
+
+# remove extra files modules_install copies in
+rm -f %{buildroot}/lib/modules/%{kernel_version}/modules.*
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+/etc/udev/rules.d/50-usb-realtek-net.rules
+
+%changelog
+* Tue Nov 12 2024 Andrew Lindh <andrew@netplex.net> - 2.19.2-1
+- Vendor driver r8152-2.19.2
+- Remove useless dire kernel warning about Private IOCTL
+- Disable TX CSUM and TSO by default as it causes problems with XCP
+
+* Thu Sep 28 2023 Andrew Lindh <andrew@netplex.net> - 2.17.1-1
+- Vendor driver r8152-2.17.1
+

--- a/SPECS/r8152-module-alt.spec
+++ b/SPECS/r8152-module-alt.spec
@@ -11,6 +11,7 @@ Source: %{name}-%{version}.tar.gz
 Patch0: 0001-compat.patch
 Patch1: 0002-disable-tx-checksum.patch
 Patch2: 0003-remove-useless-warning.patch
+Patch3: 0004-install-rules-non-root.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel


### PR DESCRIPTION
Update to Vendor driver r8152 version 2.19.2
Remove useless dire kernel warning about Private IOCTL
Disable TX CSUM and TSO by default as it causes problems with XCP

While this USB driver supports newer USB ethernet devices, it does not make XCP totally support USB devices.
This is just a device driver that allows XCP to see the network interfaces.

